### PR TITLE
Example building and running MLP graph using MDF API

### DIFF
--- a/mdf_gme/output.py
+++ b/mdf_gme/output.py
@@ -1,0 +1,13 @@
+from neuromllite.utils import _parse_element
+from modeci_mdf.mdf import Model
+from modeci_mdf.simple_scheduler import EvaluableGraph
+import json
+
+data = json.loads("""{"Simple":{"format":"ModECI MDF v0.1","generating_application":"Python modeci-mdf v0.1.2","notes":"","graphs":{"simple_example":{"notes":"","nodes":{"processing_node":{"parameters":{"slope":0.5,"logistic_gain":3,"intercept":0},"input_ports":{"input_port1":{"shape":"(1,)"}},"functions":{"logistic_1":{"function":"logistic","args":{"gain":"logistic_gain","bias":0,"variable0":"linear_1","offset":0}},"linear_1":{"function":"linear","args":{"variable0":"input_port1","intercept":"intercept","slope":"slope"}}},"output_ports":{"output_1":{"value":"logistic_1"}}},"input_node":{"parameters":{"input_level":0.5},"output_ports":{"out_port":{"value":"input_level"}}}},"edges":{"input_edge":{"sender":"input_node","receiver":"processing_node","sender_port":"out_port","receiver_port":"input_port1"}}}}}}""")
+model = Model()
+model = _parse_element(data, model)
+print('----')
+print(model)
+graph = model.graphs[0]
+egraph = EvaluableGraph(graph, False)
+result = graph  # DeepForge requires the concept of interest to be available as "result"

--- a/mdf_to_pytorch/mlp_pure_mdf.py
+++ b/mdf_to_pytorch/mlp_pure_mdf.py
@@ -1,0 +1,152 @@
+from modeci_mdf.mdf import *
+from modeci_mdf.simple_scheduler import EvaluableGraph
+from modeci_mdf.export.graphviz import mdf_to_graphviz
+
+import numpy as np
+import sys
+import h5py
+
+def get_weight_info():
+
+    weights = {}
+    f = h5py.File('example_mdfs/mlp_classifier/weights.h5', 'r')
+
+    for key in list(f.keys()):
+        weight_mat = f[key][:]
+        weights[key] = weight_mat
+        print('Loaded %s: %s'%(key, weight_mat.shape))
+    f.close()
+
+    return weights
+
+def get_model_graph():
+
+    mod = Model(id='mlp_mdf_classifier')
+    mod_graph = Graph(id=mod.id)
+    mod.graphs.append(mod_graph)
+
+    weights = get_weight_info()
+
+    dim0 = 16
+    weight = weights['weights.mlp_classifier.graphs.mlp_classifier.nodes.mlp_input_layer.parameters.weight']
+    bias = weights['weights.mlp_classifier.graphs.mlp_classifier.nodes.mlp_input_layer.parameters.bias']
+
+    dummy_input = np.zeros((14*14))
+    #dummy_input = np.ones((14*14))
+
+    input_node = Node(
+        id="mlp_input_layer",
+        parameters={"input": dummy_input,
+                    "weight":weight.T,
+                    "bias":bias.T},
+    )
+
+    f1 = Function(id="mul", function="MatMul", args={"A": 'input', "B": "weight"} )
+
+    input_node.functions.append(f1)
+
+    f2 = Function(id="sum", function="linear",
+        args={"variable0": 'mul', "slope": 1, "intercept": "bias"})
+    input_node.functions.append(f2)
+
+    input_node.output_ports.append(OutputPort(id="out_port", value='sum'))
+    mod_graph.nodes.append(input_node)
+
+
+    relu1_node = Node(id="mlp_relu_1")
+    relu1_node.input_ports.append(InputPort(id="in_port"))
+    mod_graph.nodes.append(relu1_node)
+
+    f1 = Function(id="relu1", function="Relu", args={"A": "in_port"})
+    relu1_node.functions.append(f1)
+
+    relu1_node.output_ports.append(OutputPort(id="out_port", value=f1.id))
+
+    e1 = Edge(id="edge_1",
+        sender=input_node.id,
+        sender_port=input_node.output_ports[0].id,
+        receiver=relu1_node.id,
+        receiver_port=relu1_node.input_ports[0].id,
+    )
+    mod_graph.edges.append(e1)
+
+
+    weight = weights['weights.mlp_classifier.graphs.mlp_classifier.nodes.mlp_hidden_layer_with_relu.parameters.weight']
+    bias = weights['weights.mlp_classifier.graphs.mlp_classifier.nodes.mlp_hidden_layer_with_relu.parameters.bias']
+
+    hr_node = Node(id="mlp_hidden_layer_with_relu",
+        parameters={"weight":weight.T,
+                    "bias":bias.T},)
+    mod_graph.nodes.append(hr_node)
+    hr_node.input_ports.append(InputPort(id="in_port"))
+
+    f1 = Function(id="mul", function="MatMul", args={"A": 'in_port', "B": "weight"} )
+    hr_node.functions.append(f1)
+
+    f2 = Function(id="sum", function="linear",
+                  args={"variable0": 'mul', "slope": 1, "intercept": "bias"})
+    hr_node.functions.append(f2)
+
+    f3 = Function(id="relu2", function="Relu", args={"A": "sum"})
+    hr_node.functions.append(f3)
+
+    hr_node.output_ports.append(OutputPort(id="out_port", value="relu2"))
+
+    e2 = Edge(id="edge_2",
+        sender=relu1_node.id,
+        sender_port=relu1_node.output_ports[0].id,
+        receiver=hr_node.id,
+        receiver_port=hr_node.input_ports[0].id,
+    )
+    mod_graph.edges.append(e2)
+
+
+
+    weight = weights['weights.mlp_classifier.graphs.mlp_classifier.nodes.mlp_output_layer.parameters.weight']
+    bias = weights['weights.mlp_classifier.graphs.mlp_classifier.nodes.mlp_output_layer.parameters.bias']
+
+    out_node = Node(id="mlp_output_layer",
+        parameters={"weight":weight.T,
+                    "bias":bias.T},)
+    mod_graph.nodes.append(out_node)
+    out_node.input_ports.append(InputPort(id="in_port"))
+
+    f1 = Function(id="mul", function="MatMul", args={"A": 'in_port', "B": "weight"} )
+    out_node.functions.append(f1)
+
+    f2 = Function(id="sum", function="linear",
+                  args={"variable0": 'mul', "slope": 1, "intercept": "bias"})
+    out_node.functions.append(f2)
+
+    out_node.output_ports.append(OutputPort(id="out_port", value="sum"))
+
+    e3 = Edge(id="edge_3",
+        sender=hr_node.id,
+        sender_port=hr_node.output_ports[0].id,
+        receiver=out_node.id,
+        receiver_port=out_node.input_ports[0].id,
+    )
+    mod_graph.edges.append(e3)
+
+    return mod_graph
+
+def main():
+
+    mod_graph = get_model_graph()
+
+    mdf_to_graphviz(mod_graph,view_on_render=True, level=3)
+
+    from neuromllite.utils import FORMAT_NUMPY, FORMAT_TENSORFLOW
+
+    format = FORMAT_TENSORFLOW if "-tf" in sys.argv else FORMAT_NUMPY
+    eg = EvaluableGraph(mod_graph, verbose=True)
+    eg.evaluate(array_format=format)
+
+    print('Finished evaluating graph using array format %s'%format)
+
+    for n in ['mlp_input_layer','mlp_relu_1','mlp_hidden_layer_with_relu','mlp_output_layer']:
+        out = eg.enodes[n].evaluable_outputs['out_port'].curr_value
+        print('Final output value of node %s: %s, shape: %s'%(n, out, out.shape))
+
+if __name__ == "__main__":
+    main()

--- a/mdf_to_pytorch/mlp_test.py
+++ b/mdf_to_pytorch/mlp_test.py
@@ -10,8 +10,13 @@ model = models["mlp_classifier"]
 imgs = np.load("example_data/imgs.npy")
 labels = np.load("example_data/labels.npy")
 
+matches = 0
 for i in range(len(imgs)):
     img = torch.Tensor(imgs[i,:,:]).view(-1, 14*14)
     target = labels[i]
     prediction = model(img)
-    print(target, prediction)
+    match = target==int(prediction)
+    if match: matches+=1
+    print('Image %i: target: %s, prediction: %s, match: %s'%(i, target, prediction, match))
+
+print('Matches: %i/%i, accuracy: %s%'%(matches,len(imgs), (100.*matches)/len(imgs)))


### PR DESCRIPTION
@patrickstock An example using the latest changes to MDF just merged to master to support arrays (https://github.com/ModECI/MDF/pull/41). It builds an equivalent graph in pure MDF using your weights/biases (stored internally in numpy arrays) which can be evaluated using the simplescheduler (`python mlp_pure_mdf.py` - generates image below also). It produced identical results to your pytorch example on the test data (`python mlp_pure_mdf.py -test`). Note:

- It doesn't store the mdf in json/yaml, it doesn't need to; it builds it and can evaluate, and even reuse the graph by replacing just the input parameter
- A hdf5 serialisation of mdf supporting arrays should be ready soon
- The MatMul/linear could be combined for efficiency
- No argmax on the graph yet, but could be added
- weights/biases could/should be moved to edges and handled in some more standard way
- It should be possible to use pytorch/tensorflow tensors in place of the ndarrays in the built/evaluated graph which may speed things up

![mlp_mdf_classifier gv](https://user-images.githubusercontent.com/1556687/114920630-8a84cb00-9e21-11eb-8777-56ece5d8397a.png)
